### PR TITLE
[DEV-102901] Django 4.2 compatibility

### DIFF
--- a/nexus/__init__.py
+++ b/nexus/__init__.py
@@ -2,6 +2,7 @@
 Nexus
 ~~~~~
 """
+
 from django.utils.module_loading import autodiscover_modules
 
 from nexus.modules import NexusModule

--- a/nexus/__init__.py
+++ b/nexus/__init__.py
@@ -11,8 +11,6 @@ __version__ = '2.1.2'
 VERSION = __version__
 __all__ = ('autodiscover', 'NexusSite', 'NexusModule', 'site')
 
-default_app_config = 'nexus.apps.NexusAppConfig'
-
 
 def autodiscover():
     autodiscover_modules('nexus_modules', register_to=site)

--- a/nexus/apps.py
+++ b/nexus/apps.py
@@ -7,6 +7,7 @@ class NexusAppConfig(AppConfig):
 
     def ready(self):
         from nexus.checks import register_checks
+
         register_checks()
 
         self.module.autodiscover()

--- a/nexus/checks.py
+++ b/nexus/checks.py
@@ -16,10 +16,12 @@ def check_requirements(app_configs, **kwargs):
 
     for req in reqs:
         if req not in settings.INSTALLED_APPS:
-            errors.append(Error(
-                "Nexus depends on '{}'".format(req),
-                id='nexus.E001',
-                hint="Add '{}' to INSTALLED_APPS or set NEXUS_SKIP_INSTALLED_APPS_REQUIREMENTS = True.".format(req),
-            ))
+            errors.append(
+                Error(
+                    "Nexus depends on '{}'".format(req),
+                    id='nexus.E001',
+                    hint="Add '{}' to INSTALLED_APPS or set NEXUS_SKIP_INSTALLED_APPS_REQUIREMENTS = True.".format(req),
+                )
+            )
 
     return errors

--- a/nexus/conf.py
+++ b/nexus/conf.py
@@ -5,6 +5,7 @@ class Settings(object):
     """
     Shadow Django's settings with a little logic
     """
+
     @property
     def MEDIA_PREFIX(self):
         prefix = getattr(settings, 'NEXUS_MEDIA_PREFIX', '/nexus/media/')

--- a/nexus/sites.py
+++ b/nexus/sites.py
@@ -95,6 +95,7 @@ class NexusSite(object):
 
         extra_permission can be used to require an extra permission for this view, such as a module permission
         """
+
         @wraps(view)
         def inner(request, *args, **kwargs):
             if not request.user.is_authenticated:
@@ -118,11 +119,13 @@ class NexusSite(object):
 
     def get_context(self, request):
         context = context_processors.csrf(request)
-        context.update({
-            'request': request,
-            'nexus_site': self,
-            'nexus_media_prefix': nexus_settings.MEDIA_PREFIX.rstrip('/'),
-        })
+        context.update(
+            {
+                'request': request,
+                'nexus_site': self,
+                'nexus_media_prefix': nexus_settings.MEDIA_PREFIX.rstrip('/'),
+            }
+        )
         return context
 
     def get_modules(self):
@@ -232,9 +235,13 @@ class NexusSite(object):
                 if not module.permission or request.user.has_perm(module.permission):
                     module_set.append((module.get_dashboard_title(), module.render_on_dashboard(request), home_url))
 
-        return self.render_to_response('nexus/dashboard.html', {
-            'module_set': module_set,
-        }, request)
+        return self.render_to_response(
+            'nexus/dashboard.html',
+            {
+                'module_set': module_set,
+            },
+            request,
+        )
 
 
 # setup the default site

--- a/nexus/sites.py
+++ b/nexus/sites.py
@@ -7,13 +7,14 @@ import urllib
 from collections import OrderedDict
 from functools import update_wrapper, wraps
 
-from django.conf.urls import url
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseNotModified, HttpResponseRedirect
 from django.shortcuts import render
 from django.template import context_processors
 from django.template.loader import render_to_string
+from django.urls import re_path
+from django.utils.decorators import method_decorator
 from django.utils.http import http_date
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
@@ -57,19 +58,19 @@ class NexusSite(object):
     def get_urls(self):
         base_urls = (
             [
-                url(r'^media/(?P<module>[^/]+)/(?P<path>.+)$', self.media, name='media'),
-                url(r'^$', self.as_view(self.dashboard), name='index'),
+                re_path(r'^media/(?P<module>[^/]+)/(?P<path>.+)$', self.media, name='media'),
+                re_path(r'^$', self.as_view(self.dashboard), name='index'),
             ],
             self.app_name,
             self.name,
         )
 
         urlpatterns = [
-            url(r'^', base_urls),
+            re_path(r'^', base_urls),
         ]
         for namespace, module in self.get_modules():
             urlpatterns += [
-                url(r'^%s/' % namespace, module.urls),
+                re_path(r'^%s/' % namespace, module.urls),
             ]
 
         return urlpatterns
@@ -199,8 +200,7 @@ class NexusSite(object):
         # Respect the If-Modified-Since header.
         statobj = os.stat(fullpath)
         mimetype = mimetypes.guess_type(fullpath)[0] or 'application/octet-stream'
-        if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'),
-                                  statobj[stat.ST_MTIME], statobj[stat.ST_SIZE]):
+        if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'), statobj[stat.ST_MTIME]):
             return HttpResponseNotModified(content_type=mimetype)
         contents = open(fullpath, 'rb').read()
         response = HttpResponse(contents, content_type=mimetype)
@@ -208,7 +208,7 @@ class NexusSite(object):
         response["Content-Length"] = len(contents)
         return response
 
-    @never_cache
+    @method_decorator(never_cache)
     def login(self, request, form_class=None):
         "Login form"
         if request.user.is_authenticated:

--- a/nexus/templatetags/nexus_helpers.py
+++ b/nexus/templatetags/nexus_helpers.py
@@ -24,10 +24,18 @@ def show_navigation(context):
     site = context.get('nexus_site', NexusModule.get_global('site'))
     request = context['request']
 
-    category_link_set = OrderedDict([(k, {
-        'label': v,
-        'links': [],
-    }) for k, v in site.get_categories()])
+    category_link_set = OrderedDict(
+        [
+            (
+                k,
+                {
+                    'label': v,
+                    'links': [],
+                },
+            )
+            for k, v in site.get_categories()
+        ]
+    )
 
     for namespace, module in site._registry.items():
         module, category = module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 120
+target-version = ["py38", "py39"]
+include = '\.pyi?$'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,27 +4,18 @@
 #
 #    __main__.py compile -r -U
 #
-atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via pytest
 beautifulsoup4==4.7.1
-coverage==4.5.3           # via pytest-cov
+coverage==7.4.1          # via pytest-cov
 docutils==0.14
-entrypoints==0.3          # via flake8
-flake8-commas==2.0.0
-flake8==3.7.7
-isort==4.3.18
-mccabe==0.6.1             # via flake8
-more-itertools==7.0.0     # via pytest
-multilint==2.4.0
-pluggy==0.11.0            # via pytest
-py==1.8.0                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8
 pygments==2.4.0
-pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.4.1
+pytest-cov==4.1.0
+pytest-django==4.8.0
+pytest==8.0.0
 pytz==2019.1
 six==1.12.0               # via multilint, pytest
 soupsieve==1.9.1          # via beautifulsoup4
-sqlparse==0.3.0
+sqlparse==0.4.4
+
+black==24.1.1
+flake8==7.0.0
+isort==5.13.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,11 @@
 [flake8]
 max-line-length = 120
+exclude =
+    .git
+    __pycache__
+    */migrations/*
+    env
+    .tox
 
 [isort]
 include_trailing_comma = True
@@ -7,13 +13,9 @@ known_first_party = nexus,testapp
 known_third_party = django
 line_length = 120
 multi_line_output = 5
-not_skip = __init__.py
+profile = black
+honor_noqa = true
+
 
 [metadata]
 license_file = LICENSE
-
-[tool:multilint]
-paths = nexus
-        runtests.py
-        setup.py
-        tests

--- a/tests/settings/dev.py
+++ b/tests/settings/dev.py
@@ -1,4 +1,5 @@
 """
 Used to run nexus locally
 """
+
 from .base import *  # noqa

--- a/tests/settings/test.py
+++ b/tests/settings/test.py
@@ -1,10 +1,12 @@
 """
 Used for the test suite run.
 """
+
 from copy import deepcopy
 
-from .base import *  # noqa
 from .base import DATABASES
+
+from .base import *  # noqa
 
 DEBUG = False
 

--- a/tests/testapp/management/commands/runserver.py
+++ b/tests/testapp/management/commands/runserver.py
@@ -2,6 +2,7 @@
 Exists to ensure you can always log in with admin/password when running in
 'dev' mode - see tests/README.rst
 """
+
 from django.contrib.auth.models import User
 from django.contrib.staticfiles.management.commands.runserver import Command as BaseCommand
 from django.core.management import call_command
@@ -12,8 +13,7 @@ class Command(BaseCommand):
         call_command('migrate', interactive=True)
         if not User.objects.exists():
             self.stdout.write(
-                "Welcome to Nexus test mode\n"
-                "Login with username 'admin', password 'password'",
+                "Welcome to Nexus test mode\n" "Login with username 'admin', password 'password'",
             )
             user = User(username='admin', is_superuser=True, is_staff=True)
             user.set_password('password')

--- a/tests/testapp/nexus_modules.py
+++ b/tests/testapp/nexus_modules.py
@@ -19,14 +19,21 @@ class HelloWorldModule(nexus.NexusModule):
         ]
 
     def render_on_dashboard(self, request):
-        return self.render_to_string('nexus/example/dashboard.html', {
-            'title': 'Hello World',
-        })
+        return self.render_to_string(
+            'nexus/example/dashboard.html',
+            {
+                'title': 'Hello World',
+            },
+        )
 
     def index(self, request):
-        return self.render_to_response("nexus/example/index.html", {
-            'title': 'Hello World',
-        }, request)
+        return self.render_to_response(
+            "nexus/example/index.html",
+            {
+                'title': 'Hello World',
+            },
+            request,
+        )
 
 
 nexus.site.register(HelloWorldModule, 'hello-world')
@@ -40,18 +47,22 @@ class SystemStatsModule(nexus.NexusModule):
     Modules don't need to have URLs, they can just appear on the dashboard -
     simply don't name `home_url` or implement `get_urls()`.
     """
+
     name = 'system-stats'
 
     def get_title(self):
         return 'System Stats'
 
     def render_on_dashboard(self, request):
-        return self.render_to_string('nexus/system-stats/dashboard.html', {
-            'stats': {
-                'num_cpus': multiprocessing.cpu_count(),
-                'platform': platform,
+        return self.render_to_string(
+            'nexus/system-stats/dashboard.html',
+            {
+                'stats': {
+                    'num_cpus': multiprocessing.cpu_count(),
+                    'platform': platform,
+                },
             },
-        })
+        )
 
 
 nexus.site.register(SystemStatsModule, 'system-stats')
@@ -62,6 +73,7 @@ class StyleGuideModule(nexus.NexusModule):
     Modules can also not appear on the dashboard, but not implementing
     render_on_dashboard, and only have URLs.
     """
+
     home_url = 'index'
     name = 'style-guide'
 
@@ -74,9 +86,13 @@ class StyleGuideModule(nexus.NexusModule):
         ]
 
     def index(self, request):
-        return self.render_to_response('nexus/styleguide/index.html', {
-            'title': 'Style Guide',
-        }, request)
+        return self.render_to_response(
+            'nexus/styleguide/index.html',
+            {
+                'title': 'Style Guide',
+            },
+            request,
+        )
 
 
 nexus.site.register(StyleGuideModule, 'style-guide')

--- a/tests/testapp/nexus_modules.py
+++ b/tests/testapp/nexus_modules.py
@@ -1,7 +1,7 @@
 import multiprocessing
 import platform
 
-from django.conf.urls import url
+from django.urls import re_path
 
 import nexus
 
@@ -15,7 +15,7 @@ class HelloWorldModule(nexus.NexusModule):
 
     def get_urls(self):
         return [
-            url(r'^$', self.as_view(self.index), name='index'),
+            re_path(r'^$', self.as_view(self.index), name='index'),
         ]
 
     def render_on_dashboard(self, request):
@@ -70,7 +70,7 @@ class StyleGuideModule(nexus.NexusModule):
 
     def get_urls(self):
         return [
-            url(r'^$', self.as_view(self.index), name='index'),
+            re_path(r'^$', self.as_view(self.index), name='index'),
         ]
 
     def index(self, request):

--- a/tests/testapp/templatetags/test_nexus_helpers.py
+++ b/tests/testapp/templatetags/test_nexus_helpers.py
@@ -11,23 +11,41 @@ class NexusHelpersTests(TestCase):
     request_factory = RequestFactory()
 
     def test_nexus_media_prefix(self):
-        out = Template('''
+        out = (
+            Template(
+                '''
             {% load nexus_media_prefix from nexus_helpers %}
             {% nexus_media_prefix %}
-        ''').render(Context()).strip()
+        '''
+            )
+            .render(Context())
+            .strip()
+        )
         assert out == '/nexus/media'
 
     def test_nexus_version(self):
-        out = Template('''
+        out = (
+            Template(
+                '''
             {% load nexus_version from nexus_helpers %}
             {% nexus_version %}
-        ''').render(Context()).strip()
+        '''
+            )
+            .render(Context())
+            .strip()
+        )
         assert out == nexus.__version__
 
     def test_show_navigation(self):
         request = self.request_factory.get('/')
-        out = Template('''
+        out = (
+            Template(
+                '''
             {% load show_navigation from nexus_helpers %}
             {% show_navigation %}
-        ''').render(RequestContext(request, {'nexus_site': site})).strip()
+        '''
+            )
+            .render(RequestContext(request, {'nexus_site': site}))
+            .strip()
+        )
         BeautifulSoup(out, 'html.parser')  # checks it is valid HTML

--- a/tests/testapp/templatetags/test_nexus_helpers.py
+++ b/tests/testapp/templatetags/test_nexus_helpers.py
@@ -1,12 +1,12 @@
 from bs4 import BeautifulSoup
 from django.template import Context, RequestContext, Template
-from django.test import RequestFactory, SimpleTestCase
+from django.test import RequestFactory, TestCase
 
 import nexus
 from nexus.sites import site
 
 
-class NexusHelpersTests(SimpleTestCase):
+class NexusHelpersTests(TestCase):
 
     request_factory = RequestFactory()
 

--- a/tests/testapp/test_conf.py
+++ b/tests/testapp/test_conf.py
@@ -1,10 +1,10 @@
-from django.test import SimpleTestCase
+from django.test import TestCase
 from django.test.utils import override_settings
 
 from nexus.conf import nexus_settings
 
 
-class NexusSettingsTests(SimpleTestCase):
+class NexusSettingsTests(TestCase):
 
     @override_settings(NEXUS_MEDIA_PREFIX='/mynexusprefix/')
     def test_with_override_settings(self):

--- a/tests/testapp/test_views.py
+++ b/tests/testapp/test_views.py
@@ -39,8 +39,9 @@ class ViewTests(TestCase):
         assert resp.status_code == 200
 
     def test_media_modified_since(self):
-        resp = self.client.get('/nexus/media/nexus/img/nexus_logo.png',
-                               HTTP_IF_MODIFIED_SINCE='Wed, 25 Feb 2065 17:42:04 GMT')
+        resp = self.client.get(
+            '/nexus/media/nexus/img/nexus_logo.png', HTTP_IF_MODIFIED_SINCE='Wed, 25 Feb 2065 17:42:04 GMT'
+        )
         assert resp.status_code == 304
 
     def test_media_non_existent(self):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,9 +1,10 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.contrib import admin
+from django.urls import re_path
 
 import nexus
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^nexus/', include(nexus.site.urls)),
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^nexus/', include(nexus.site.urls)),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
 envlist =
-    py3-django{111,20,21,22},
-    py3-codestyle
+    py{38,39,310}-django{32,42},
+    py38-codestyle
 
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1
-install_command = pip install --no-deps {opts} {packages}
+; install_command = pip install --no-deps {opts} {packages}
 deps =
-    django111: Django>=1.11a1,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
-    django22: Django>=2.2,<2.3
+    django32: Django>=3.2,<4.0
+    django42: Django>=4.2,<5.0
     -rrequirements.txt
-commands = ./runtests.py {posargs}
+commands = python runtests.py {posargs}
 
-[testenv:py3-codestyle]
+[testenv:py38-codestyle]
 deps = -rrequirements.txt
-skip_install = true
-commands = multilint
+commands =
+    black -S nexus tests runtests.py setup.py
+    isort nexus tests runtests.py setup.py
+    flake8


### PR DESCRIPTION
This PR makes nexus work in Django 4.2.

Steps performed here:
* Solved deprecation warnings
  * Removed `default_app_config`: [docs](https://docs.djangoproject.com/en/4.2/releases/4.1/#features-removed-in-4-1)
  * Changed `url` to `re_path`: [docs](https://docs.djangoproject.com/en/4.2/releases/3.1/#id2)
* Bumped outdated dependencies
* Ran linting and code formatters
* Fixed failing tests

To test this, install `pyenv` and run `tox`